### PR TITLE
Fix leaking of sqlite3_stmt's

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -7,7 +7,10 @@ class YsqlppProject(ConanFile):
     version = "0.1"
     requires = (
         "spdlog/1.9.2",
-        "sqlite3/3.36.0"
+        "sqlite3/3.36.0",
+        "catch2/2.13.8",
+        "fmt/8.1.1",
+        "spdlog/1.9.2"
     )
     generators = "cmake", "gcc", "txt", "cmake_find_package"
     

--- a/examples/simple/main.cpp
+++ b/examples/simple/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021, Fredrik Andersson
+// Copyright (C) 2021-2022, Fredrik Andersson
 // SPDX-License-Identifier: CC-BY-NC-4.0
 
 #include <exception>
@@ -28,7 +28,7 @@ int main(int /*argc*/, const char ** /*argv*/) {
     exec(db, "insert into ROOM (NAME, VALUE) values ('Emma', " + std::to_string(dist(rd)) + ");");
     exec(db, "insert into ROOM (NAME, VALUE) values ('Liza', " + std::to_string(dist(rd)) + ");");
 
-    auto *stmt = y44::ysqlpp::prepare_single(db, "select * from ROOM;");
+    auto stmt = y44::ysqlpp::prepare_single(db, "select * from ROOM;");
     y44::ysqlpp::for_each(stmt, [](const std::string &name, double val) {
       spdlog::info("{}:{}\n", name, val);
     });

--- a/include/ysqlpp/exec.h
+++ b/include/ysqlpp/exec.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2021, Fredrik Andersson
+// Copyright (C) 2021-2022, Fredrik Andersson
 // SPDX-License-Identifier: CC-BY-NC-4.0
 
 #pragma once
@@ -14,6 +14,7 @@
 #include "db.h"
 #include "prepare.h"
 #include "step.h"
+#include "stmt.h"
 
 namespace y44::ysqlpp::impl {
   [[nodiscard]] inline std::string trim(const std::string &str) {

--- a/include/ysqlpp/for_each.h
+++ b/include/ysqlpp/for_each.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2021, Fredrik Andersson
+// Copyright (C) 2021-2022, Fredrik Andersson
 // SPDX-License-Identifier: CC-BY-NC-4.0
 
 #pragma once
@@ -8,13 +8,14 @@
 #include <sqlite3.h>
 
 #include "step.h"
+#include "stmt.h"
 
 namespace y44::ysqlpp {
   template <typename F>
-  void for_each(sqlite3_stmt *stmt, F &&f) {
+  void for_each(Stmt &stmt, F &&f) {
     while(auto r = step(stmt, std::forward<F>(f))) {
     }
 
-    sqlite3_reset(stmt);
+    sqlite3_reset(stmt.get());
   }
 }// namespace y44::ysqlpp

--- a/include/ysqlpp/prepare.h
+++ b/include/ysqlpp/prepare.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2021, Fredrik Andersson
+// Copyright (C) 2021-2022, Fredrik Andersson
 // SPDX-License-Identifier: CC-BY-NC-4.0
 
 #pragma once
@@ -11,24 +11,26 @@
 #include <sqlite3.h>
 
 #include "db.h"
+#include "stmt.h"
 
 namespace y44::ysqlpp::impl {
-  [[nodiscard]] inline std::pair<sqlite3_stmt *, const char *> prepare(y44::ysqlpp::DB &db, std::string_view sql) {
+  [[nodiscard]] inline std::pair<Stmt, const char *> prepare(y44::ysqlpp::DB &db, std::string_view sql) {
     const char *s = sql.data();
     const char *remain = nullptr;
     sqlite3_stmt *stmt = nullptr;
     auto rc = sqlite3_prepare(db.get(), s, -1, &stmt, &remain);
-    if(rc != SQLITE_OK) {
+    if(rc != SQLITE_OK /*&& stmt != nullptr*/) {
       const auto *msg = sqlite3_errmsg(db.get());
       auto c = sqlite3_extended_errcode(db.get());
       throw std::runtime_error(std::string{msg} + " (" + std::to_string(c) + ")");
     }
-    return {stmt, remain};
+
+    return {Stmt{stmt}, remain};
   }
 }// namespace y44::ysqlpp::impl
 
 namespace y44::ysqlpp {
-  [[nodiscard]] inline sqlite3_stmt *prepare_single(y44::ysqlpp::DB &db, std::string_view sql) {
+  [[nodiscard]] inline Stmt prepare_single(y44::ysqlpp::DB &db, std::string_view sql) {
     return y44::ysqlpp::impl::prepare(db, sql).first;
   }
 }// namespace y44::ysqlpp

--- a/include/ysqlpp/stmt.h
+++ b/include/ysqlpp/stmt.h
@@ -1,0 +1,48 @@
+// Copyright (C) 2022, Fredrik Andersson
+// SPDX-License-Identifier: CC-BY-NC-4.0
+
+#pragma once
+
+#include <memory>
+
+#include "sqlite3.h"
+
+namespace y44::ysqlpp {
+  class Stmt {
+    public:
+      Stmt() = delete;
+
+      explicit Stmt(sqlite3_stmt *stmt) : m_stmt(stmt, &sqlite3_finalize) {}
+
+      // move
+      Stmt(Stmt &&rhs) noexcept : m_stmt(nullptr, &sqlite3_finalize) {
+        std::swap(m_stmt, rhs.m_stmt);
+      }
+
+      // copy
+      Stmt(const Stmt &) = delete;
+
+      ~Stmt() noexcept = default;
+
+      // copy assignment operator
+      Stmt operator=(const Stmt &) = delete;
+
+      // move asignment operator
+      Stmt &operator=(Stmt &&rhs) noexcept {
+        std::swap(m_stmt, rhs.m_stmt);
+        return *this;
+      }
+
+      explicit operator sqlite3_stmt *() {
+        return m_stmt.get();
+      }
+
+      sqlite3_stmt *get() noexcept {
+        return m_stmt.get();
+      }
+
+    private:
+      std::unique_ptr<sqlite3_stmt, decltype(&sqlite3_finalize)> m_stmt;
+  };
+
+}// namespace y44::ysqlpp

--- a/include/ysqlpp/ysqlpp.h
+++ b/include/ysqlpp/ysqlpp.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2021, Fredrik Andersson
+// Copyright (C) 2021-2022, Fredrik Andersson
 // SPDX-License-Identifier: CC-BY-NC-4.0
 
 #pragma once
@@ -8,3 +8,4 @@
 #include "for_each.h"
 #include "open.h"
 #include "step.h"
+#include "stmt.h"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 find_package(Catch2 REQUIRED)
 find_package(SQLite3 REQUIRED)
+find_package(fmt REQUIRED)
 
 include(CTest)
 include(Catch)
@@ -15,7 +16,9 @@ target_compile_features(tests PRIVATE cxx_std_20)
 target_link_libraries(tests PRIVATE 
 project_warnings project_options 
 catch_main
-SQLite3)
+SQLite3
+Catch2::Catch2
+fmt::fmt)
 
 target_include_directories(tests PRIVATE ${PROJECT_SOURCE_DIR}/include)
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1,19 +1,24 @@
-// Copyright (C) 2021, Fredrik Andersson
+// Copyright (C) 2021-2022, Fredrik Andersson
 // SPDX-License-Identifier: CC-BY-NC-4.0
 
+#include <algorithm>
 #include <filesystem>
+#include <fmt/core.h>
 #include <iostream>
 #include <random>
 #include <vector>
 
 #include <catch2/catch.hpp>
+#include <fmt/format.h>
 
-#include <ysqlpp.h>
+#include "../include/ysqlpp/ysqlpp.h"
+#include "ysqlpp/for_each.h"
+#include "ysqlpp/prepare.h"
 
 std::filesystem::path get_random_file() {
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_int_distribution<> dist{1000L, 9999L};
+  std::uniform_int_distribution<> dist{1000L, 9999L};// NOLINT
 
   auto f = std::filesystem::temp_directory_path();
   do {
@@ -49,7 +54,7 @@ TEST_CASE("step", "[step]") {
   {
     auto db = create_db(db_path);
 
-    auto *stmt = y44::ysqlpp::prepare_single(db, "select count(NAME) from MYTABLE;");
+    auto stmt = y44::ysqlpp::prepare_single(db, "select count(NAME) from MYTABLE;");
 
     int64_t count_rows{0};
     y44::ysqlpp::step(stmt, [&count_rows](int64_t c) {
@@ -66,7 +71,7 @@ TEST_CASE("For Each Row", "[for_each]") {
   {
     auto db = create_db(db_path);
 
-    auto *stmt = y44::ysqlpp::prepare_single(db, "select NAME from MYTABLE;");
+    auto stmt = y44::ysqlpp::prepare_single(db, "select NAME from MYTABLE;");
     std::vector<std::string> vec;
     y44::ysqlpp::for_each(stmt, [&vec](const std::string &name) {
       vec.push_back(name);
@@ -86,7 +91,7 @@ TEST_CASE("pass db as shared_ptr", "[shared_ptr]") {
   {
     auto db = std::make_shared<y44::ysqlpp::DB>(create_db(db_path));
 
-    auto *stmt = y44::ysqlpp::prepare_single(*db, "select count(NAME) from MYTABLE;");
+    auto stmt = y44::ysqlpp::prepare_single(*db, "select count(NAME) from MYTABLE;");
 
     int64_t count_rows{0};
     y44::ysqlpp::step(stmt, [&count_rows](int64_t c) {
@@ -95,5 +100,38 @@ TEST_CASE("pass db as shared_ptr", "[shared_ptr]") {
 
     REQUIRE(count_rows == 3);
   }
+  std::filesystem::remove(db_path);
+}
+
+
+TEST_CASE("Many db write and reads", "[READ/Write DB]") {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<double> dist{0.0, 999999.0};// NOLINT
+  dist(gen);
+
+  // std::vector<double> data_values(100'000);
+  // std::generate(data_values.begin(), data_values.end(), [&dist, &gen]() { return dist(gen); });
+  const size_t COUNT_DATA_VALUES = 100'000;
+  const auto db_path = get_random_file();
+  {
+    auto db = y44::ysqlpp::open(db_path);
+    y44::ysqlpp::exec(db, "create table if not exists MYTABLE (NAME text, VALUE float);");
+
+    for(size_t i = 0; i < COUNT_DATA_VALUES; i++) {
+      auto sql = fmt::format("insert into MYTABLE (NAME, VALUE) values ('Name0', {} );", dist(gen));
+      y44::ysqlpp::exec(db, sql);
+    }
+
+    /*********/
+
+    auto stmt = y44::ysqlpp::prepare_single(db, "select VALUE from MYTABLE");
+    size_t row_count{};
+    y44::ysqlpp::for_each(stmt, [&row_count](double /*v*/) {
+      ++row_count;
+    });
+    REQUIRE(row_count == COUNT_DATA_VALUES);
+  }
+
   std::filesystem::remove(db_path);
 }


### PR DESCRIPTION
Fixes #1 

Raw sqlite3_stmt* was used thouout the code, without calling
sqlite3_finalize. Reworked code to encapsulate pointers on
separate class, with a std::unique_ptr with custom deleter to
wrapp the stmt object.

Refactored Db class to also use std::unique_ptr.

Signed-off-by: Fredrik Andersson <fredrik.k.andersson@gmail.com>